### PR TITLE
Syntax error in Pi version

### DIFF
--- a/platforms/raspberrypi/Gearboy/main.cpp
+++ b/platforms/raspberrypi/Gearboy/main.cpp
@@ -343,7 +343,7 @@ int main(int argc, char** argv)
             else
             {
                 end();
-                printf("invalid option: %s\n", argv[i])
+                printf("invalid option: %s\n", argv[i]);
                 return -1;
             }
         }


### PR DESCRIPTION
Looks like a simple typo; it was missing a semicolon. Luckily that's within my ability to fix. :)

(Compiling the rest on a Pi right now. Hopefully all else will go well. I'll file an issue if anything else comes up.)

Thanks for adding the Pi to the available platforms!
