### PR TITLE
Implemented save/load state (excluding state slots)

### DIFF
--- a/platforms/qt-shared/Emulator.cpp
+++ b/platforms/qt-shared/Emulator.cpp
@@ -103,6 +103,21 @@ void Emulator::MemoryDump()
     m_Mutex.unlock();
 }
 
+void Emulator::MemorySaveState(std::string filename)
+{
+    m_Mutex.lock();
+    m_pGearboyCore->GetMemory()->MemorySaveState(filename);
+    m_Mutex.unlock();
+}
+
+void Emulator::MemoryLoadState(std::string filename)
+{
+    m_Mutex.lock();
+    m_pGearboyCore->GetMemory()->MemoryLoadState(filename);
+    m_Mutex.unlock();
+}
+
+
 void Emulator::SetSoundSettings(bool enabled, int rate)
 {
     m_Mutex.lock();

--- a/platforms/qt-shared/Emulator.h
+++ b/platforms/qt-shared/Emulator.h
@@ -38,6 +38,8 @@ public:
     bool IsPaused();
     void Reset(bool forceDMG);
     void MemoryDump();
+    void MemorySaveState(std::string filename);
+    void MemoryLoadState(std::string filename);
     void SetSoundSettings(bool enabled, int rate);
     void SetDMGPalette(GB_Color& color1, GB_Color& color2, GB_Color& color3, GB_Color& color4);
     void SaveRam();

--- a/platforms/qt-shared/MainWindow.cpp
+++ b/platforms/qt-shared/MainWindow.cpp
@@ -28,6 +28,7 @@
 #include "SoundSettings.h"
 #include "VideoSettings.h"
 #include "About.h"
+#include <unistd.h>
 
 MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent)
 {
@@ -62,6 +63,8 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent)
     m_pUI->actionX_3->setData(3);
     m_pUI->actionX_4->setData(4);
     m_pUI->actionX_5->setData(5);
+
+    stateFile = "slot1.gbs";
 
     m_pEmulator = new Emulator();
     m_pEmulator->Init();
@@ -154,18 +157,64 @@ void MainWindow::MenuGameBoySelectStateSlot()
 
 void MainWindow::MenuGameBoySaveState()
 {
+    // Pause emulation, to not cause havok while dumping memory
+    m_pEmulator->Pause();
+    m_pEmulator->MemorySaveState(stateFile);
+    m_pEmulator->Resume();
 }
 
 void MainWindow::MenuGameBoyLoadState()
 {
+    // Pause emulation, to not cause havok while overwriting memory
+    m_pEmulator->Pause();
+    m_pEmulator->MemoryLoadState(stateFile);
+    m_pEmulator->Resume();
 }
 
 void MainWindow::MenuGameBoySaveStateAs()
 {
+    m_pGLFrame->PauseRenderThread();
+
+    QString filename = QFileDialog::getSaveFileName(
+            this,
+            tr("Save State"),
+            QDir::currentPath(),
+            tr("All files (*.*)"));
+
+    if (!filename.isNull())
+    {
+        m_pEmulator->Pause();
+        m_pEmulator->MemorySaveState(filename.toStdString().c_str());
+        m_pEmulator->Resume();
+    }
+
+    setFocus();
+    activateWindow();
+
+    m_pGLFrame->ResumeRenderThread();
 }
 
 void MainWindow::MenuGameBoyLoadStateFrom()
 {
+    m_pGLFrame->PauseRenderThread();
+
+    QString filename = QFileDialog::getOpenFileName(
+            this,
+            tr("Save State"),
+            QDir::currentPath(),
+            tr("All files (*.*)"));
+
+    if (!filename.isNull())
+    {
+        m_pEmulator->Pause();
+        m_pEmulator->MemoryLoadState(filename.toStdString().c_str());
+        m_pEmulator->Resume();
+    }
+
+    setFocus();
+    activateWindow();
+
+    m_pGLFrame->ResumeRenderThread();
 }
 
 void MainWindow::MenuSettingsInput()

--- a/platforms/qt-shared/MainWindow.h
+++ b/platforms/qt-shared/MainWindow.h
@@ -93,6 +93,7 @@ private:
     bool m_bMenuPressed[3];
     int m_iScreenSize;
     bool m_bFullscreen;
+    std::string stateFile;
     QShortcut* m_pExitShortcut;
     InputSettings* m_pInputSettings;
     SoundSettings* m_pSoundSettings;

--- a/src/Memory.cpp
+++ b/src/Memory.cpp
@@ -228,6 +228,74 @@ void Memory::MemoryDump(const char* szFilePath)
     }
 }
 
+void Memory::MemorySaveState(std::string szFilePath)
+{
+    using namespace std;
+
+    // Open file to save the current state to
+    ofstream myfile(szFilePath.c_str(), ios::out | ios::trunc);
+
+    if (myfile.is_open())
+    {
+        // Save CPU registers using comma separation
+        myfile << (u16) m_pProcessor->AF.GetValue() << ",";
+        myfile << (u16) m_pProcessor->BC.GetValue() << ",";
+        myfile << (u16) m_pProcessor->DE.GetValue() << ",";
+        myfile << (u16) m_pProcessor->HL.GetValue() << ",";
+        myfile << (u16) m_pProcessor->SP.GetValue() << ",";
+        myfile << (u16) m_pProcessor->PC.GetValue() << ",";
+
+        // Save RAM using comma separation
+        for (int i = 0; i < 65536; i++)
+        {
+            myfile << (int) m_pMap[i] << ",";
+        }
+
+        myfile.close();
+    }
+    // File is inaccessible
+    // Else: Maybe show an appropriate message to the user
+}
+
+// Auxiliary function to read next u16 from csv file
+u16 getNextValueFromFile(std::ifstream &myfile)
+{
+    using namespace std;
+    string astring;
+    getline( myfile, astring, ',' );
+
+    return (u16) atoi(astring.c_str());
+}
+
+void Memory::MemoryLoadState(std::string szFilePath)
+{
+    using namespace std;
+
+    // Open file to load the current state from
+    ifstream myfile(szFilePath.c_str(), fstream::in);
+
+    if (myfile.is_open())
+    {
+        // Load CPU registers from csv file
+        m_pProcessor->AF.SetValue(getNextValueFromFile(myfile));
+        m_pProcessor->BC.SetValue(getNextValueFromFile(myfile));
+        m_pProcessor->DE.SetValue(getNextValueFromFile(myfile));
+        m_pProcessor->HL.SetValue(getNextValueFromFile(myfile));
+        m_pProcessor->SP.SetValue(getNextValueFromFile(myfile));
+        m_pProcessor->PC.SetValue(getNextValueFromFile(myfile));
+
+        // Load RAM from csv file
+        for (int i = 0; i < 65536; i++)
+        {
+            m_pMap[i] = getNextValueFromFile(myfile);
+        }
+
+        myfile.close();
+    }
+    // File not found or inaccessible
+    // Else: Maybe show an appropriate message to the user
+}
+
 void Memory::PerformDMA(u8 value)
 {
     if (m_bCGB)

--- a/src/Memory.h
+++ b/src/Memory.h
@@ -24,6 +24,7 @@
 #include "boot_roms.h"
 #include "MemoryRule.h"
 #include <vector>
+#include "SixteenBitRegister.h"
 
 class Processor;
 class Video;
@@ -57,6 +58,8 @@ public:
     bool IsDisassembled(u16 address);
     void LoadBank0and1FromROM(u8* pTheROM);
     void MemoryDump(const char* szFilePath);
+    void MemorySaveState(std::string szFilePath);
+    void MemoryLoadState(std::string szFilePath);
     void PerformDMA(u8 value);
     void SwitchCGBDMA(u8 value);
     unsigned int PerformHDMA();

--- a/src/Processor.h
+++ b/src/Processor.h
@@ -53,18 +53,18 @@ public:
     void AddCycles(unsigned int cycles);
     bool InterruptIsAboutToRaise();
     bool BootROMfinished() const;
-
-private:
-    typedef void (Processor::*OPCptr) (void);
-    OPCptr m_OPCodes[256];
-    OPCptr m_OPCodesCB[256];
-    Memory* m_pMemory;
     SixteenBitRegister AF;
     SixteenBitRegister BC;
     SixteenBitRegister DE;
     SixteenBitRegister HL;
     SixteenBitRegister SP;
     SixteenBitRegister PC;
+
+private:
+    typedef void (Processor::*OPCptr) (void);
+    OPCptr m_OPCodes[256];
+    OPCptr m_OPCodesCB[256];
+    Memory* m_pMemory;
     bool m_bIME;
     bool m_bHalt;
     bool m_bBranchTaken;


### PR DESCRIPTION
I read in the readme.md (before the 74ce318 commit), that save and load state weren't implemented, so i gave it a shot.

I implemented it quite simply by saving/loading the CPU registers and RAM to/from a csv file. To use it, just load a ROM and save the state at some point (using the menu button or CMD+S) and load it again later (using the menu button or CMD+L).

I have discovered 1 bug, that I'm not sure how to fix. Loading a state before the Nintendo boot-up logo disappears, causes the game to freeze. Maybe there is a way to skip the logo?

P.S.
This is my first pull request, so please be patient if I made some mistakes.