### PR TITLE
Fix rendering glitches on Mac OS X

### DIFF
--- a/platforms/qt-shared/GLFrame.cpp
+++ b/platforms/qt-shared/GLFrame.cpp
@@ -58,12 +58,12 @@ bool GLFrame::IsRunningRenderThread()
 {
     return m_RenderThread.IsRunningEmulator();
 }
-/*
+
 void GLFrame::resizeEvent(QResizeEvent *evt)
 {
-    //m_RenderThread.ResizeViewport(evt->size(), this->devicePixelRatio());
+    m_RenderThread.ResizeViewport(evt->size(), this->devicePixelRatio());
 }
-*/
+
 void GLFrame::resizeGL(int width, int height)
 {
     m_RenderThread.ResizeViewport(QSize(width, height), 1/*this->devicePixelRatio()*/);

--- a/platforms/qt-shared/GLFrame.h
+++ b/platforms/qt-shared/GLFrame.h
@@ -46,7 +46,7 @@ public:
 
 protected:
     void closeEvent(QCloseEvent *evt);
-    //void resizeEvent(QResizeEvent *evt);
+    void resizeEvent(QResizeEvent *evt);
     void paintEvent(QPaintEvent *);
     void resizeGL(int width, int height);
 

--- a/platforms/qt-shared/RenderThread.cpp
+++ b/platforms/qt-shared/RenderThread.cpp
@@ -94,6 +94,7 @@ void RenderThread::run()
                 m_bFirstFrame = true;
             }
 
+            m_pGLFrame->makeCurrent();
             if (m_bMixFrames && !m_pEmulator->IsCGBRom())
                 RenderMixFrames();
             else


### PR DESCRIPTION
Well, after submitting drhelius/Gearsystem#7, I found your another work, which surprisingly resemble Gearsystem. On a quick glance, it also has similar rendering issues, but also seems you already tried to handle this. But using `resizeGL()` instead of `resizeEvent()` gave me only crash on startup. Here is my fix.

- Restore overriding `resizeEvent()` like you did in Gearsystem.
- Add a call for `makeCurrent()` in `RenderThread`.

Now it runs nicely and switch different resolutions with no crash. Hope it works for you too.