### PR TITLE
Tune compilation for Raspberry Pi 2 and 3

### DIFF
--- a/platforms/raspberrypi2/Gearboy/Makefile.include
+++ b/platforms/raspberrypi2/Gearboy/Makefile.include
@@ -1,4 +1,4 @@
-CFLAGS+=-Wall -O3 -march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard
+CFLAGS+=-Wall -O3 -march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -mtune=cortex-a7
 
 LDFLAGS+=-L$(SDKSTAGE)/opt/vc/lib/ -lbrcmEGL -lbrcmGLESv2 -lopenmaxil -lvcos -lvchiq_arm -lm -lrt -lconfig++ -lbcm_host `sdl2-config --libs`
 

--- a/platforms/raspberrypi3/Gearboy/Makefile.include
+++ b/platforms/raspberrypi3/Gearboy/Makefile.include
@@ -1,4 +1,4 @@
-CFLAGS+=-Wall -O3 -march=armv8-a+crc -mfpu=neon-fp-armv8 -mfloat-abi=hard
+CFLAGS+=-Wall -O3 -march=armv8-a+crc -mfpu=neon-fp-armv8 -mfloat-abi=hard -mtune=cortex-a53
 
 LDFLAGS+=-L$(SDKSTAGE)/opt/vc/lib/ -lbrcmEGL -lbrcmGLESv2 -lopenmaxil -lvcos -lvchiq_arm -lm -lrt -lconfig++ -lbcm_host `sdl2-config --libs`
 


### PR DESCRIPTION
By telling the compiler the target CPU it can optimize better and apply errata workarounds if needed.