### PR TITLE
Add static GBC RAM banks to libretro memory map

### DIFF
--- a/platforms/libretro/libretro.cpp
+++ b/platforms/libretro/libretro.cpp
@@ -363,7 +363,7 @@ bool retro_load_game(const struct retro_game_info *info)
 
     snprintf(retro_game_path, sizeof(retro_game_path), "%s", info->path);
 
-    struct retro_memory_descriptor descs[9];
+    struct retro_memory_descriptor descs[10];
 
     memset(descs, 0, sizeof(descs));
 
@@ -403,6 +403,10 @@ bool retro_load_game(const struct retro_game_info *info)
     descs[8].ptr   = core->GetMemory()->GetMemoryMap() + 0xFE00;
     descs[8].start = 0xFE00;
     descs[8].len   = 0x00A0;
+    // Static RAM banks
+    descs[9].ptr   = core->IsCGB() ? (core->GetMemory()->GetCGBRAM() + 0x1000) : (core->GetMemory()->GetMemoryMap() + 0xD000);
+    descs[9].start = 0x10000;
+    descs[9].len   = core->IsCGB() ? 0x7000 : 0;
 
     struct retro_memory_map mmaps;
     mmaps.descriptors = descs;


### PR DESCRIPTION
This matches a change to the reference map as applied here: https://github.com/RetroAchievements/RAIntegration/commit/6d710b17c33fc1e729eeaf2fbd1bc4c7d011c429.

The region is appended to the tail end to maintain backwards-compatibility.