### PR TITLE
(libretro) Remove usage of obsolete Cell SDK

### DIFF
--- a/platforms/libretro/Makefile
+++ b/platforms/libretro/Makefile
@@ -144,11 +144,11 @@ else ifneq (,$(filter $(platform), ngc wii wiiu))
       CXXFLAGS += -DHW_DOL -mrvl
    endif
 # PS3
-else ifeq ($(platform), ps3)
+else ifneq (,$(filter $(platform), ps3 psl1ght))
    TARGET := $(TARGET_NAME)_libretro_$(platform).a
-   CC = $(CELL_SDK)/host-win32/ppu/bin/ppu-lv2-gcc.exe
-   CXX = $(CELL_SDK)/host-win32/ppu/bin/ppu-lv2-g++.exe
-   AR = $(CELL_SDK)/host-win32/ppu/bin/ppu-lv2-ar.exe
+   CC = $(PS3DEV)/ppu/bin/ppu-gcc$(EXE_EXT)
+   CXX = $(PS3DEV)/ppu/bin/ppu-g++$(EXE_EXT)
+   AR = $(PS3DEV)/ppu/bin/ppu-ar$(EXE_EXT)
    CXXFLAGS += -DMINIZ_NO_TIME -DMINIZ_NO_STDIO -Wall -D__ppc__ -DMSB_FIRST
    STATIC_LINKING = 1
 # OSX

--- a/platforms/libretro/libretro.h
+++ b/platforms/libretro/libretro.h
@@ -69,7 +69,7 @@ extern "C" {
 #      endif
 #    endif
 #  else
-#      if defined(__GNUC__) && __GNUC__ >= 4 && !defined(__CELLOS_LV2__)
+#      if defined(__GNUC__) && __GNUC__ >= 4
 #        define RETRO_API RETRO_CALLCONV __attribute__((__visibility__("default")))
 #      else
 #        define RETRO_API RETRO_CALLCONV


### PR DESCRIPTION
The libretro folks have obsoleted use of the Cell SDK, in favor of the PSL1GHT SDK, which supposedly produces less buggy PS3 binaries, so Gearboy should probably do the same.