### PR TITLE
add retrofw target

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -254,6 +254,12 @@ libretro-build-rs90-odbeta-mips32:
     - .libretro-rs90-odbeta-mips32-make-default
     - .core-defs
 
+# RetroFW
+libretro-build-retrofw-mips32:
+  extends:
+    - .libretro-retrofw-mips32-make-default
+    - .core-defs
+
 #################################### MISC ##################################
 # Emscripten
 libretro-build-emscripten:

--- a/platforms/libretro/Makefile
+++ b/platforms/libretro/Makefile
@@ -235,6 +235,17 @@ else ifeq ($(platform), gcw0)
    PLATFORM_DEFINES := -DCC_RESAMPLER -DCC_RESAMPLER_NO_HIGHPASS
    CFLAGS += -fomit-frame-pointer -ffast-math -march=mips32 -mtune=mips32r2 -mhard-float
    CXXFLAGS += $(CFLAGS)
+# RETROFW
+else ifeq ($(platform), retrofw)
+   TARGET := $(TARGET_NAME)_libretro.so
+   CC = /opt/retrofw-toolchain/usr/bin/mipsel-linux-gcc
+   CXX = /opt/retrofw-toolchain/usr/bin/mipsel-linux-g++
+   AR = /opt/retrofw-toolchain/usr/bin/mipsel-linux-ar
+   fpic := -fPIC
+   SHARED := -shared -Wl,-version-script=$(CORE_DIR)/link.T
+   PLATFORM_DEFINES := -DCC_RESAMPLER -DCC_RESAMPLER_NO_HIGHPASS
+   CFLAGS += -fomit-frame-pointer -ffast-math -march=mips32 -mtune=mips32 -mhard-float
+   CXXFLAGS += $(CFLAGS)
 # PS2
 else ifeq ($(platform), ps2)
    TARGET := $(TARGET_NAME)_libretro_$(platform).a


### PR DESCRIPTION
Retrofw is a OD like CFW running on the jz4760 chipsets and retroarch already has retrofw as a target.

Retrofw is almost identical to OD jz4770 in most respects, except that the chipset is half as powerful.

I would like to add retrofw as a target to CI to your excellent gearboy core which is by far my favorite gb core.

I will definetely add gearcoleco in the near future as well.

Thank you in advance