### PR TITLE
[libretro] Fix cross-compiling with mingw

### DIFF
--- a/platforms/libretro/libretro.cpp
+++ b/platforms/libretro/libretro.cpp
@@ -27,16 +27,12 @@
 #include <math.h>
 
 #include <stdio.h>
-#if defined(_WIN32) && !defined(_XBOX)
-#include <windows.h>
-#endif
 #include "libretro.h"
 
 #include "../../src/gearboy.h"
 
 #define VIDEO_WIDTH 160
 #define VIDEO_HEIGHT 144
-#define VIDEO_PIXELS (VIDEO_WIDTH * VIDEO_HEIGHT)
 
 #ifdef _WIN32
 static const char slash = '\\';

--- a/src/Cartridge.cpp
+++ b/src/Cartridge.cpp
@@ -20,6 +20,7 @@
 #include <string>
 #include <algorithm>
 #include <ctype.h>
+#include <time.h>
 #include "Cartridge.h"
 #include "miniz/miniz.c"
 


### PR DESCRIPTION
I cross-compiled with mingw in Linux, to see if that windows.h include in platforms/libretro/libretro.cpp was necessary.  It wasn't, but including time.h in src/Cartridge.cpp was.