### PR TITLE
Fix compiler crash

### DIFF
--- a/platforms/libretro/Makefile
+++ b/platforms/libretro/Makefile
@@ -212,7 +212,7 @@ else ifneq (,$(findstring qnx,$(platform)))
 else ifeq ($(platform), emscripten)
    TARGET := $(TARGET_NAME)_libretro_emscripten.bc
    fpic := -fPIC
-   SHARED := -shared -Wl,--version-script=$(CORE_DIR)/link.T -Wl,--no-undefined
+   SHARED := -shared -Wl,--version-script=$(CORE_DIR)/link.T -Wl
 # RS90
 else ifeq ($(platform), rs90)
    TARGET := $(TARGET_NAME)_libretro.so


### PR DESCRIPTION
`--no-undefined` is not a valid emscripten compiler flag and will crash the compiler (on newer versions of emscripten)