### PR TITLE
macos:DYLIB path update for homebrew apple silicon

### DIFF
--- a/platforms/macos/Makefile
+++ b/platforms/macos/Makefile
@@ -1,6 +1,6 @@
 include ../desktop-shared/Makefile.common
 
-DYLIB_PATH=/usr/local/opt/sdl2/lib
+DYLIB_PATH=/opt/homebrew/opt/sdl2/lib
 SDL_DYLIB=libSDL2-2.0.0.dylib
 APP_NAME=Gearboy
 


### PR DESCRIPTION
https://docs.brew.sh/FAQ#why-should-i-install-homebrew-in-the-default-location

```
/usr/local for macOS on Intel
/opt/homebrew for macOS on Apple Silicon/ARM
```