### PR TITLE
Macos apple silicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you find a bug or want new features, you can help me [openning an issue](http
 
 - **Windows**: [Gearboy-3.4.0-Windows.zip](https://github.com/drhelius/Gearboy/releases/download/gearboy-3.4.0/Gearboy-3.4.0-Windows.zip)
   + NOTE: You may need to install the [Microsoft Visual C++ Redistributable](https://go.microsoft.com/fwlink/?LinkId=746572)
-- **macOS**:
+- **macOS (Intel)**:
   + `brew install --cask gearboy`
   + Or install manually: [Gearboy-3.4.0-macOS.zip](https://github.com/drhelius/Gearboy/releases/download/gearboy-3.4.0/Gearboy-3.4.0-macOS.zip)
 - **Linux**: [Gearboy-3.4.0-Linux.tar.xz](https://github.com/drhelius/Gearboy/releases/download/gearboy-3.4.0/Gearboy-3.4.0-Linux.tar.xz)

--- a/platforms/macos/Makefile
+++ b/platforms/macos/Makefile
@@ -1,6 +1,15 @@
 include ../desktop-shared/Makefile.common
 
-DYLIB_PATH=/usr/local/opt/sdl2/lib
+
+# Brew use a different path on Apple Silicon as on Intel
+UNAME_P := $(shell uname -m)
+ifneq ($(filter arm64%,$(UNAME_P)),)
+	DYLIB_PATH=/opt/homebrew/lib/
+else
+	DYLIB_PATH=/usr/local/opt/sdl2/lib
+endif
+
+
 SDL_DYLIB=libSDL2-2.0.0.dylib
 APP_NAME=Gearboy
 


### PR DESCRIPTION
Adjusted the MacOS Makefile for building Gearbox on Intel and also Apple Silicon (M1/M2..) Macs.