### PR TITLE
Add UI scaling slider

### DIFF
--- a/platforms/desktop-shared/application.cpp
+++ b/platforms/desktop-shared/application.cpp
@@ -196,6 +196,8 @@ static int sdl_init(void)
         float scale_h = (float)display_h / h;
 
         application_display_scale = (scale_w > scale_h) ? scale_w : scale_h;
+
+        application_display_scale *= config_video.ui_scale;
     }
 
     SDL_EventState(SDL_DROPFILE, SDL_ENABLE);

--- a/platforms/desktop-shared/config.cpp
+++ b/platforms/desktop-shared/config.cpp
@@ -143,6 +143,7 @@ void config_read(void)
     }
     config_video.sync = read_bool("Video", "Sync", true);
     config_video.color_correction = read_bool("Video", "ColorCorrection", true);
+    config_video.ui_scale = read_float("Video", "UIScale", 1.0f);
     
     config_audio.enable = read_bool("Audio", "Enable", true);
     config_audio.sync = read_bool("Audio", "Sync", true);
@@ -239,6 +240,7 @@ void config_write(void)
     }
     write_bool("Video", "Sync", config_video.sync);
     write_bool("Video", "ColorCorrection", config_video.color_correction);
+    write_float("Video", "UIScale", config_video.ui_scale);
 
     write_bool("Audio", "Enable", config_audio.enable);
     write_bool("Audio", "Sync", config_audio.sync);

--- a/platforms/desktop-shared/config.h
+++ b/platforms/desktop-shared/config.h
@@ -84,6 +84,7 @@ struct config_Video
     };
     bool sync = true;
     bool color_correction = true;
+    float ui_scale = 1.0f;
 };
 
 struct config_Audio

--- a/platforms/desktop-shared/gui.cpp
+++ b/platforms/desktop-shared/gui.cpp
@@ -54,6 +54,8 @@ static bool status_message_active = false;
 static char status_message[4096] = "";
 static u32 status_message_start_time = 0;
 static u32 status_message_duration = 0;
+static float original_ui_scale = 1.0f;
+static bool ui_scale_changed = false;
 
 static void main_menu(void);
 static void main_window(void);
@@ -96,6 +98,10 @@ void gui_init(void)
         Log("Error: %s", NFD_GetError());
     }
 
+    // Store the original UI scale value to detect changes
+    original_ui_scale = config_video.ui_scale;
+    ui_scale_changed = false;
+
     IMGUI_CHECKVERSION();
     ImGui::CreateContext();
     ImGui::StyleColorsDark();
@@ -104,8 +110,6 @@ void gui_init(void)
     io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
     io.ConfigDockingWithShift = true;
     io.IniFilename = config_imgui_file_path;
-
-    io.FontGlobalScale /= application_display_scale;
 
 #if defined(__APPLE__) || defined(_WIN32)
     if (config_debug.multi_viewport)
@@ -698,6 +702,30 @@ static void main_menu(void)
                 emu_color_correction(config_video.color_correction);
             }
 
+            ImGui::Separator();
+
+            // Always show the warning if scale is different from original
+            if (ui_scale_changed)
+            {
+                ImGui::Text("UI Scale:");
+                ImGui::SameLine();
+                ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.0f, 0.0f, 1.0f));
+                ImGui::Text("(restart required)");
+                ImGui::PopStyleColor();
+            }
+            else
+            {
+                ImGui::Text("UI Scale:");
+            }
+
+            ImGui::PushItemWidth(250.0f);
+            if (ImGui::SliderFloat("##ui_scale", &config_video.ui_scale, 1.0f, 3.0f, "%.1f"))
+            {
+                // Check if the value has changed from the original value
+                ui_scale_changed = (config_video.ui_scale != original_ui_scale);
+            }
+            ImGui::PopItemWidth();
+
             if (ImGui::BeginMenu("Screen Ghosting"))
             {
                 ImGui::MenuItem("Enable Screen Ghosting", "", &config_video.mix_frames);
@@ -1046,9 +1074,9 @@ static void main_window(void)
     if (config_debug.debug)
     {
         if (config_video.scale != 0)
-            scale_multiplier = config_video.scale_manual;
+            scale_multiplier = config_video.scale_manual * application_display_scale;
         else
-            scale_multiplier = 1;
+            scale_multiplier = 1 * application_display_scale;
     }
     else
     {
@@ -1878,29 +1906,29 @@ static void set_style(void)
 
     style.Alpha = 1.0f;
     style.DisabledAlpha = 0.6000000238418579f;
-    style.WindowPadding = ImVec2(8.0f, 8.0f);
-    style.WindowRounding = 4.0f;
-    style.WindowBorderSize = 1.0f;
-    style.WindowMinSize = ImVec2(32.0f, 32.0f);
+    style.WindowPadding = ImVec2(8.0f, 8.0f) * application_display_scale;
+    style.WindowRounding = 4.0f * application_display_scale;
+    style.WindowBorderSize = 1.0f * application_display_scale;
+    style.WindowMinSize = ImVec2(32.0f, 32.0f) * application_display_scale;
     style.WindowTitleAlign = ImVec2(0.0f, 0.5f);
     style.WindowMenuButtonPosition = ImGuiDir_Left;
     style.ChildRounding = 0.0f;
-    style.ChildBorderSize = 1.0f;
-    style.PopupRounding = 4.0f;
-    style.PopupBorderSize = 1.0f;
-    style.FramePadding = ImVec2(4.0f, 3.0f);
-    style.FrameRounding = 2.5f;
+    style.ChildBorderSize = 1.0f * application_display_scale;
+    style.PopupRounding = 4.0f * application_display_scale;
+    style.PopupBorderSize = 1.0f * application_display_scale;
+    style.FramePadding = ImVec2(4.0f, 3.0f) * application_display_scale;
+    style.FrameRounding = 2.5f * application_display_scale;
     style.FrameBorderSize = 0.0f;
-    style.ItemSpacing = ImVec2(8.0f, 4.0f);
-    style.ItemInnerSpacing = ImVec2(4.0f, 4.0f);
-    style.CellPadding = ImVec2(4.0f, 2.0f);
-    style.IndentSpacing = 21.0f;
-    style.ColumnsMinSpacing = 6.0f;
-    style.ScrollbarSize = 11.0f;
-    style.ScrollbarRounding = 2.5f;
-    style.GrabMinSize = 10.0f;
-    style.GrabRounding = 2.0f;
-    style.TabRounding = 3.5f;
+    style.ItemSpacing = ImVec2(8.0f, 4.0f) * application_display_scale;
+    style.ItemInnerSpacing = ImVec2(4.0f, 4.0f) * application_display_scale;
+    style.CellPadding = ImVec2(4.0f, 2.0f) * application_display_scale;
+    style.IndentSpacing = 21.0f * application_display_scale;
+    style.ColumnsMinSpacing = 6.0f * application_display_scale;
+    style.ScrollbarSize = 11.0f * application_display_scale;
+    style.ScrollbarRounding = 2.5f * application_display_scale;
+    style.GrabMinSize = 10.0f * application_display_scale;
+    style.GrabRounding = 2.0f * application_display_scale;
+    style.TabRounding = 3.5f * application_display_scale;
     style.TabBorderSize = 0.0f;
     style.TabMinWidthForCloseButton = 0.0f;
     style.ColorButtonPosition = ImGuiDir_Right;

--- a/platforms/desktop-shared/gui_debug.cpp
+++ b/platforms/desktop-shared/gui_debug.cpp
@@ -1746,7 +1746,7 @@ static void debug_window_vram_tiles(void)
 
 static void debug_window_vram_oam(void)
 {
-    float scale = 3.0f * application_display_scale;
+    float scale = 5.0f * application_display_scale;
     float width = 8.0f * scale;
     float height_8 = 8.0f * scale;
     float height_16 = 16.0f * scale;

--- a/platforms/desktop-shared/gui_debug.cpp
+++ b/platforms/desktop-shared/gui_debug.cpp
@@ -87,6 +87,13 @@ void gui_debug_windows(void)
 {
     if (config_debug.debug)
     {
+        // Set display scale for all memory editors
+        for (int i = 0; i < 10; i++)
+        {
+            mem_edit[i].SetDisplayScale(application_display_scale);
+            mem_edit[i].SetGuiFont(gui_default_font);
+        }
+
         if (config_debug.show_processor)
             debug_window_processor();
         if (config_debug.show_memory)
@@ -1443,7 +1450,7 @@ static void debug_window_vram_background(void)
     static bool show_screen = true;
     static int tile_address_radio = 0;
     static int map_address_radio = 0;
-    float scale = 1.5f;
+    float scale = 1.5f * application_display_scale;
     float size = 256.0f * scale;
     float spacing = 8.0f * scale;
 
@@ -1642,7 +1649,7 @@ static void debug_window_vram_tiles(void)
 {
     static bool show_grid = true;
     bool window_hovered = ImGui::IsWindowHovered();
-    float scale = 1.5f;
+    float scale = 1.5f * application_display_scale;
     float width = 8.0f * 16.0f * scale;
     float height = 8.0f * 24.0f * scale;
     float spacing = 8.0f * scale;
@@ -1739,7 +1746,7 @@ static void debug_window_vram_tiles(void)
 
 static void debug_window_vram_oam(void)
 {
-    float scale = 5.0f;
+    float scale = 3.0f * application_display_scale;
     float width = 8.0f * scale;
     float height_8 = 8.0f * scale;
     float height_16 = 16.0f * scale;
@@ -1757,7 +1764,7 @@ static void debug_window_vram_oam(void)
     ImGui::PushFont(gui_default_font);
 
     ImGui::Columns(2, "oam", false);
-    ImGui::SetColumnOffset(1, 280.0f);
+    ImGui::SetColumnOffset(1, 280.0f * application_display_scale);
 
     ImGui::BeginChild("sprites", ImVec2(0, 0), true);
 
@@ -1788,7 +1795,7 @@ static void debug_window_vram_oam(void)
 
     ImVec2 p_screen = ImGui::GetCursorScreenPos();
 
-    float screen_scale = 1.5f;
+    float screen_scale = 1.5f * application_display_scale;
 
     ImGui::Image((ImTextureID)(intptr_t)renderer_emu_texture, ImVec2(GAMEBOY_WIDTH * screen_scale, GAMEBOY_HEIGHT * screen_scale));
 

--- a/platforms/desktop-shared/imgui/memory_editor.cpp
+++ b/platforms/desktop-shared/imgui/memory_editor.cpp
@@ -46,6 +46,7 @@ MemEditor::MemEditor()
     m_goto_address[0] = 0;
     m_add_bookmark = false;
     m_draw_list = 0;
+    m_display_scale = 1.0f;
 }
 
 MemEditor::~MemEditor()
@@ -86,7 +87,7 @@ void MemEditor::Draw(uint8_t* mem_data, int mem_size, int base_display_addr, int
     int separator_count = (m_bytes_per_row - 1) / 4;
     int byte_column_count = 2 + m_bytes_per_row + separator_count + 2;
     int byte_cell_padding = 0;
-    int ascii_padding = 4;
+    int ascii_padding = 4 * m_display_scale;
     int character_cell_padding = 0;
     int max_chars_per_cell = 2 * m_mem_word;
     ImVec2 character_size = ImGui::CalcTextSize("0");
@@ -95,7 +96,7 @@ void MemEditor::Draw(uint8_t* mem_data, int mem_size, int base_display_addr, int
     if (options)
         footer_height += ImGui::GetFrameHeightWithSpacing();
     if (preview)
-        footer_height += ((character_size.y + 4) * 3) + 4;
+        footer_height += ((character_size.y + 4 * m_display_scale) * 3) + 4 * m_display_scale;
     if (cursors)
         footer_height += ImGui::GetFrameHeightWithSpacing();
 
@@ -931,4 +932,9 @@ std::vector<MemEditor::Bookmark>* MemEditor::GetBookmarks()
 void MemEditor::SetGuiFont(ImFont* gui_font)
 {
     m_gui_font = gui_font;
+}
+
+void MemEditor::SetDisplayScale(float scale)
+{
+    m_display_scale = scale;
 }

--- a/platforms/desktop-shared/imgui/memory_editor.h
+++ b/platforms/desktop-shared/imgui/memory_editor.h
@@ -50,6 +50,7 @@ public:
     void RemoveBookmarks();
     std::vector<Bookmark>* GetBookmarks();
     void SetGuiFont(ImFont* gui_font);
+    void SetDisplayScale(float scale);
 
 private:
     bool IsColumnSeparator(int current_column, int column_count);
@@ -91,6 +92,7 @@ private:
     std::vector<Bookmark> m_bookmarks;
     ImFont* m_gui_font;
     ImDrawList* m_draw_list;
+    float m_display_scale;
 };
 
 #endif	/* MEM_EDITOR_H */


### PR DESCRIPTION
The UI scaling on my 4k display on Ubuntu 22.04 is tiny:

![image](https://github.com/user-attachments/assets/7c79c6a1-803b-412e-baea-48d21312986f)


I've added a slider that can scale the UI, acting as an additional multiplier (not a direct override):

![image](https://github.com/user-attachments/assets/f1f559fb-005e-4165-89a9-0ae4e470948f)

With the UI scaled, it's more comfortable for high-DPI screens:

![image](https://github.com/user-attachments/assets/2284e6f7-c103-4360-8a36-f2e04f9fb21f)
