### PR TITLE
Adding processor breakpoint enable/disable button.

### DIFF
--- a/platforms/desktop-shared/gui_debug.cpp
+++ b/platforms/desktop-shared/gui_debug.cpp
@@ -1892,6 +1892,7 @@ static void add_breakpoint_cpu(void)
             map[target_offset]->size = 0;
             map[target_offset]->jump = false;
             map[target_offset]->jump_address = 0;
+            map[target_offset]->disabled = false;
             for (int i = 0; i < 4; i++)
                 map[target_offset]->opcodes[i] = 0;
         }

--- a/platforms/desktop-shared/gui_debug.cpp
+++ b/platforms/desktop-shared/gui_debug.cpp
@@ -324,14 +324,24 @@ static void debug_window_disassembler(void)
             if (!IsValidPointer((*breakpoints_cpu)[b]))
                 continue;
 
-            ImGui::PushID(b);
+            ImGui::PushID(2 * b);
             if (ImGui::SmallButton("X"))
             {
                remove = b;
                ImGui::PopID();
                continue;
             }
+            ImGui::PopID();
 
+            ImGui::SameLine();
+
+            ImGui::PushID(2 * b + 1);
+            ImGui::PushStyleColor(ImGuiCol_Button, !(*breakpoints_cpu)[b]->disabled ? green : ImGui::GetStyle().Colors[ImGuiCol_Button]);
+            if (ImGui::SmallButton("E"))
+            {
+                (*breakpoints_cpu)[b]->disabled = !(*breakpoints_cpu)[b]->disabled;
+            }
+            ImGui::PopStyleColor(1);
             ImGui::PopID();
 
             ImGui::PushFont(gui_default_font);

--- a/src/Memory.h
+++ b/src/Memory.h
@@ -42,6 +42,7 @@ public:
         u8 opcodes[4];
         bool jump;
         u16 jump_address;
+        bool disabled;
     };
 
     struct stMemoryBreakpoint

--- a/src/Processor.cpp
+++ b/src/Processor.cpp
@@ -484,6 +484,7 @@ bool Processor::Disassemble(u16 address)
         map[offset]->size = 0;
         map[offset]->jump = false;
         map[offset]->jump_address = 0;
+        map[offset]->disabled = false;
         for (int i = 0; i < 4; i++)
             map[offset]->opcodes[i] = 0;
     }

--- a/src/Processor.cpp
+++ b/src/Processor.cpp
@@ -587,7 +587,7 @@ bool Processor::Disassemble(u16 address)
 
         for (std::size_t b = 0; b < size; b++)
         {
-            if ((*breakpoints)[b] == map[offset])
+            if (((*breakpoints)[b] == map[offset]) && !(*breakpoints)[b]->disabled)
             {
                 return true;
             }


### PR DESCRIPTION
Inspired by GDB's capability of disabling/enabling breakpoints, I added an enable button directly next to the delete button of a processor breakpoint. This allows to disable a breakpoint without deleting it.
Unfortunately, to keep track of deleted breakpoints I had to add a field to `struct stDisassembleRecord`.
If you like the idea as well, I could add the same feature for memory breakpoints .
Furthermore, one could get rid of `emu_debug_disable_breakpoints_cpu` by simply disabling all breakpoints.
Any feedback is welcome.