### PR TITLE
Fix config not being set on first run

### DIFF
--- a/platforms/desktop-shared/config.cpp
+++ b/platforms/desktop-shared/config.cpp
@@ -93,10 +93,11 @@ void config_read(void)
     if (!config_ini_file->read(config_ini_data))
     {
         Log("Unable to load settings from %s", config_emu_file_path);
-        return;
     }
-
-    Log("Loading settings from %s", config_emu_file_path);
+    else
+    {
+        Log("Loading settings from %s", config_emu_file_path);
+    }
 
     config_debug.debug = read_bool("Debug", "Debug", false);
     config_debug.show_audio = read_bool("Debug", "Audio", false);

--- a/platforms/desktop-shared/config.h
+++ b/platforms/desktop-shared/config.h
@@ -52,9 +52,9 @@ struct config_Emulator
     bool show_info = false;
     int mbc = 0;
     std::string recent_roms[config_max_recent_roms];
-    bool dmg_bootrom;
+    bool dmg_bootrom = false;
     std::string dmg_bootrom_path;
-    bool gbc_bootrom;
+    bool gbc_bootrom = false;
     std::string gbc_bootrom_path;
     int savefiles_dir_option = 0;
     std::string savefiles_path;


### PR DESCRIPTION
Early return means the defaults were never loaded on the first run of the application, which led to the save ending up in the same directory as the game and not in the default directory(which is set the 2nd launch as it finds the config and corrects the empty config to the default path).

Which led to me nearly having a panic attack thinking my save had disappeared :D.

Also fixes 2 missing default values in config_Emulator(this doesn't fix anything as they're set from the config but everything should have defaults).