### PR TITLE
Fix MCP adapter to auto-detect cartridge type from ROM header

### DIFF
--- a/platforms/shared/desktop/mcp/mcp_debug_adapter.cpp
+++ b/platforms/shared/desktop/mcp/mcp_debug_adapter.cpp
@@ -73,7 +73,7 @@ void DebugAdapter::StepFrame()
 
 void DebugAdapter::Reset()
 {
-    emu_reset(false, Cartridge::CartridgeNoMBC, false);
+    emu_reset(false, Cartridge::CartridgeNotSupported, false);
 }
 
 json DebugAdapter::GetDebugStatus()
@@ -1194,7 +1194,7 @@ json DebugAdapter::LoadMedia(const std::string& file_path)
         return result;
     }
 
-    emu_load_rom_async(file_path.c_str(), false, Cartridge::CartridgeNoMBC, false);
+    emu_load_rom_async(file_path.c_str(), false, Cartridge::CartridgeNotSupported, false);
 
     int timeout_ms = 180000;
     int elapsed_ms = 0;


### PR DESCRIPTION
## Summary

- The MCP debug adapter hardcodes `Cartridge::CartridgeNoMBC` in both `LoadMedia` and `Reset`, forcing `RomOnlyMemoryRule` for all ROMs loaded via MCP — regardless of their actual MBC type.
- This silently breaks any ROM that uses a memory bank controller (MBC1, MBC3, MBC5, etc.): bank switch writes to `$2000`–`$3FFF` are discarded, the CPU reads uninitialized `$FF` bytes from the wrong bank, and execution crashes into `RST $38`.
- The fix changes both call sites to `Cartridge::CartridgeNotSupported`, the sentinel value that triggers auto-detection from the ROM header byte at `$0147`. This matches the GUI code path, which returns `CartridgeNotSupported` via `gui_get_mbc()` for its default "Auto" setting.

## How it was found

While debugging a GBDK-2020 Game Boy Color homebrew game (MBC5+RAM+Battery, 16 ROM banks) loaded via the MCP interface, the game crashed immediately at `$0038` (`RST $38` vector). The ROM worked fine in SameBoy and when loaded via Gearboy's GUI.

Tracing the issue: the GBDK banked call trampoline at `$3F31` correctly wrote `$02` to the MBC5 bank register at `$2000`, but `RomOnlyMemoryRule::PerformWrite` silently ignored the write (it just logs a debug message for writes to `$0000`–`$7FFF`). The CPU then fetched code from physical bank 1 instead of bank 2, hit `$FF` bytes (uninitialized ROM), and crashed.

## Changes

`platforms/shared/desktop/mcp/mcp_debug_adapter.cpp` — two lines:

| Line | Before | After |
|------|--------|-------|
| 76 (`Reset`) | `Cartridge::CartridgeNoMBC` | `Cartridge::CartridgeNotSupported` |
| 1197 (`LoadMedia`) | `Cartridge::CartridgeNoMBC` | `Cartridge::CartridgeNotSupported` |

## Test plan

- [ ] Load a ROM-only game (e.g. Tetris) via MCP `load_media` — should still work as before
- [ ] Load an MBC1 game (e.g. Pokémon Red) via MCP `load_media` — should auto-detect MBC1 and handle bank switching
- [ ] Load an MBC5 game via MCP `load_media` — should auto-detect MBC5 and handle bank switching
- [ ] Verify `debug_reset` preserves auto-detection (doesn't revert to ROM-only)
- [ ] Compare behavior with loading the same ROMs via the GUI (should now be identical)

🤖 Generated with [Claude Code](https://claude.ai/code)